### PR TITLE
Add different heroku process files for docker

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   usedocker:
     description: "Will deploy using Dockerfile in project root."
     default: false
+  docker_heroku_process_type:
+    description: "Type of heroku process (web, worker, etc). This option only makes sense when usedocker enabled"
+    default: web
+    required: false
   appdir:
     description: "Set if your app is located in a subdirectory."
     default: ""

--- a/index.js
+++ b/index.js
@@ -51,8 +51,7 @@ heroku.buildpack = core.getInput("buildpack");
 heroku.branch = core.getInput("branch");
 heroku.dontuseforce = core.getInput("dontuseforce") === "true" ? true : false;
 heroku.usedocker = core.getInput("usedocker") === "true" ? true : false;
-const dockerHerokuProcessType = core.getInput("docker_heroku_process_type");
-heroku.dockerHerokuProcessType = dockerHerokuProcessType ? dockerHerokuProcessType : "web";
+heroku.dockerHerokuProcessType = core.getInput("docker_heroku_process_type");
 heroku.appdir = core.getInput("appdir");
 
 // Program logic

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ machine git.heroku.com
     password ${api_key}
 EOF`;
 
-const deploy = ({ dontuseforce, app_name, branch, usedocker, appdir }) => {
+const deploy = ({ dontuseforce, app_name, branch, usedocker, dockerHerokuProcessType, appdir }) => {
   const force = !dontuseforce ? "--force" : "";
 
   if (usedocker) {
-    execSync(`heroku container:push web --app ${app_name}`);
-    execSync(`heroku container:release web --app ${app_name}`);
+    execSync(`heroku container:push ${dockerHerokuProcessType} --app ${app_name}`);
+    execSync(`heroku container:release ${dockerHerokuProcessType} --app ${app_name}`);
   } else {
     if (appdir === "") {
       execSync(`git push heroku ${branch}:refs/heads/master ${force}`);
@@ -51,6 +51,8 @@ heroku.buildpack = core.getInput("buildpack");
 heroku.branch = core.getInput("branch");
 heroku.dontuseforce = core.getInput("dontuseforce") === "true" ? true : false;
 heroku.usedocker = core.getInput("usedocker") === "true" ? true : false;
+const dockerHerokuProcessType = core.getInput("docker_heroku_process_type");
+heroku.dockerHerokuProcessType = dockerHerokuProcessType ? dockerHerokuProcessType : "web";
 heroku.appdir = core.getInput("appdir");
 
 // Program logic


### PR DESCRIPTION
Heroku has a few different process types, "web" exposes port to listen HTTP traffic, and "worker" considered to use for getting background batch jobs
https://devcenter.heroku.com/articles/asynchronous-web-worker-model-using-rabbitmq-in-java#worker-process
So I need an option which allows to deploy not only web type of container 

Yes, I thought about more universal way for setting type of Dyno, hoverer it's hard to consider all edge cases, so I implemented just simple way to do this

It's only valuable for docker because for usual deployments Procfile solves this problem (I guess for docker deployments, too, but it's a bit easier to use such way as I proposed)