### PR TITLE
Fix: Replaces ambiguous master ref when appdir is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const deploy = ({ dontuseforce, app_name, branch, usedocker, dockerHerokuProcess
       execSync(`git push heroku ${branch}:refs/heads/master ${force}`);
     } else {
       execSync(
-        `git push ${force} heroku \`git subtree split --prefix=${appdir} ${branch}\`:master`
+        `git push ${force} heroku \`git subtree split --prefix=${appdir} ${branch}\`:refs/heads/master`
       );
     }
   }


### PR DESCRIPTION
When appdir is set, the git push was behaving differently. It attempted to push to :master, which works when a repository is already set up on Heroku's side. However, on initial app creation (or first git push), we need to explicitly push to refs/heads/master or our git push will complain. We were already doing this for the non-appdir code path.

**Steps Performed**
* [x] Checkout, `npm install`, `npm test`
* [x] Manually performed git action locally to verify no errors

Fixes #11 (full details in bug report)