### PR TITLE
Support Docker build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The action comes with additional options that you can use to configure your proj
 | dontuseforce               | false    | Set this to true if you don't want to use --force when switching branches                                                                                                                           | true or false                                         |
 | usedocker                  | false    | Will deploy using Dockerfile in project root                                                                                                                                                        | true or false                                         |
 | docker_heroku_process_type | false    | Type of heroku process (web, worker, etc). This option only makes sense when usedocker enabled. Defaults to "web" (Thanks to [singleton11](https://github.com/singleton11) for adding this feature) | web, worker                                           |
+| docker_build_args          | false    | A list of args to pass into the Docker build. This option only makes sense when usedocker enabled.                                                                                                  | NODE_ENV                                              |
 | appdir                     | false    | Set if your app is located in a subdirectory                                                                                                                                                        | api, apis/python                                      |
 | healthcheck                | false    | A URL to which a healthcheck is performed (checks for 200 request)                                                                                                                                  | https://demo-rest-api.herokuapp.com                   |
 | checkstring                | false    | Value to check for when conducting healthcheck requests                                                                                                                                             | ok                                                    |
@@ -105,9 +106,40 @@ jobs:
           usedocker: true
 ```
 
-P.S: Keep in mind that if you deploy once using docker, the same heroku app is not compatible with a non-docker setup and similarly, you cannot deploy a dockerized setup to a non-docker heroku app.
+Keep in mind that if you deploy once using docker, the same heroku app is not compatible with a non-docker setup and similarly, you cannot deploy a dockerized setup to a non-docker heroku app.
 
-Also thanks to [Olav Sundfør](https://github.com/olaven) for adding this feature
+If you need to pass in any ARGs for the Docker build, you may provide a list of arg names which automatically pull from the environment.
+
+_.github/workflows/main.yml_
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.3.6 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "YOUR APP's NAME" #Must be unique in Heroku
+          heroku_email: "YOUR EMAIL"
+          usedocker: true
+          docker_build_args: |
+            NODE_ENV
+            SECRET_KEY
+        env:
+          NODE_ENV: production
+          SECRET_KEY: ${{ secret.MY_SECRET_KEY }}
+```
+
+Also, thanks to [Olav Sundfør](https://github.com/olaven) for adding the Docker feature and [Matt Stavola](https://github.com/mbStavola) for adding the ability to pass in build args.
 
 ### Deploy with custom Buildpacks
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
     description: "Type of heroku process (web, worker, etc). This option only makes sense when usedocker enabled"
     default: "web"
     required: false
+  docker_build_args:
+    description: "A list of args to pass into the Docker build. This option only makes sense when usedocker enabled"
+    required: false
   appdir:
     description: "Set if your app is located in a subdirectory."
     default: ""

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ if (heroku.appdir) {
 // Collate docker build args into arg list
 if (heroku.dockerBuildArgs) {
   heroku.dockerBuildArgs = heroku.dockerBuildArgs.split('\n')
-    .map(arg => `${arg}=\${{ env.${arg} }}`)
+    .map(arg => `${arg}=${process.env[arg]}`)
     .join(',');
   heroku.dockerBuildArgs = heroku.dockerBuildArgs ?
     `--arg ${heroku.dockerBuildArgs}` :

--- a/index.js
+++ b/index.js
@@ -56,12 +56,13 @@ const deploy = ({
   branch,
   usedocker,
   dockerHerokuProcessType,
+  dockerBuildArgs,
   appdir,
 }) => {
   const force = !dontuseforce ? "--force" : "";
   if (usedocker) {
     execSync(
-      `heroku container:push ${dockerHerokuProcessType} --app ${app_name}`,
+      `heroku container:push ${dockerHerokuProcessType} --app ${app_name} ${dockerBuildArgs}`,
       appdir ? { cwd: appdir } : null
     );
     execSync(
@@ -89,6 +90,7 @@ let heroku = {
   dontuseforce: core.getInput("dontuseforce") === "true" ? true : false,
   usedocker: core.getInput("usedocker") === "true" ? true : false,
   dockerHerokuProcessType: core.getInput("docker_heroku_process_type"),
+  dockerBuildArgs: core.getInput("docker_build_args"),
   appdir: core.getInput("appdir"),
   healthcheck: core.getInput("healthcheck"),
   checkstring: core.getInput("checkstring"),
@@ -104,6 +106,16 @@ if (heroku.appdir) {
       : heroku.appdir[0] === "/"
       ? heroku.appdir.slice(1)
       : heroku.appdir;
+}
+
+// Collate docker build args into arg list
+if (heroku.dockerBuildArgs) {
+  heroku.dockerBuildArgs = heroku.dockerBuildArgs.split('\n')
+    .map(arg => `${arg}=\${{ env.${arg} }}`)
+    .join(',');
+  heroku.dockerBuildArgs = heroku.dockerBuildArgs ?
+    `--arg ${heroku.dockerBuildArgs}` :
+    '';
 }
 
 (async () => {


### PR DESCRIPTION
First off, thanks for this action! There are a few Heroku actions, but this one is by far the most flexible and ergonomic.

I ran into a bit of a roadblock when it came to one of my services because it required some ARGs. Luckily, [Heroku supports][1] passing in build args for Docker images, which was _really_ easy to add into this Action.

Here is an example usage:

```yml
      - uses: akhileshns/heroku-deploy@v3.3.6 # This is the action
        with:
          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
          heroku_app_name: "YOUR APP's NAME" #Must be unique in Heroku
          heroku_email: "YOUR EMAIL"
          usedocker: true
          docker_build_args: |
            NODE_ENV
            SECRET_KEY
        env:
          NODE_ENV: production
          SECRET_KEY: ${{ secret.MY_SECRET_KEY }}
```

`docker_build_args` takes a newline delimited list of names that it'll pull from the environment. Since you are manually passing in the args, it seemed reasonable and easier to just pull from the environment directly instead of requiring a prefix like `HD_`.

[1]: https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-container-push