### PR TITLE
Handle special characters in config values

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const addConfig = ({ app_name, env_file, appdir }) => {
   let configVars = [];
   for (let key in process.env) {
     if (key.startsWith("HD_")) {
-      configVars.push(key.substring(3) + "=" + process.env[key]);
+      configVars.push(key.substring(3) + "='" + process.env[key] + "'");
     }
   }
   if (env_file) {


### PR DESCRIPTION
Config values can sometimes include special characters or spaces. This change wraps the value in single quotes to ensure values don't cause bash errors in the final command.

I've tested it and confirmed config values are sent and set properly.