### PR TITLE
Add recursive and context-path options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ The action comes with additional options that you can use to configure your proj
 | dontautocreate              | false    | Set this to true if you don't want to automatically create the Heroku app                                                                                                                           | true or false                                         |
 | dontuseforce                | false    | Set this to true if you don't want to use --force when switching branches                                                                                                                           | true or false                                         |
 | usedocker                   | false    | Will deploy using Dockerfile in project root                                                                                                                                                        | true or false                                         |
-| context_path                | false    | Set if you want to set path to use as build context (defaults to Dockerfile dir)                                                                                                                    | . , api                                               |
-| userecursive                | false    | Set this to true if you want to use --recursive for pushes Dockerfile.<process> found in current and subdirectories                                                                                 | true or false                                         |
+| context_path                | false    | Set if you want to set path to use as build context (defaults to Dockerfile dir)                                                                                                                    | ., api                                                |
+| userecursive                | false    | Set this to true if you want to use --recursive for pushes Dockerfile.process found in current and subdirectories                                                                                   | true or false                                         |
 | docker_heroku_process_type  | false    | Type of heroku process (web, worker, etc). This option only makes sense when usedocker enabled. Defaults to "web" (Thanks to [singleton11](https://github.com/singleton11) for adding this feature) | web, worker                                           |
 | docker_build_args           | false    | A list of args to pass into the Docker build. This option only makes sense when usedocker enabled.                                                                                                  | NODE_ENV                                              |
 | appdir                      | false    | Set if your app is located in a subdirectory                                                                                                                                                        | api, apis/python                                      |
@@ -166,7 +166,7 @@ jobs:
           SECRET_KEY: ${{ secrets.MY_SECRET_KEY }}
 ```
 
-You can use `userecursive` and `context_path` options if you storing Dockerfile in subdirectories, Heroku will searching Dockerfile in current and subdirectories and build at the context path.
+You can use `userecursive` and `context_path` options if your Dockerfile is located in a subdirectory. Heroku will search for Dockerfile in current and subdirectories then build at the context path.
 
 _.github/workflows/main.yml_
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The action comes with additional options that you can use to configure your proj
 | dontautocreate              | false    | Set this to true if you don't want to automatically create the Heroku app                                                                                                                           | true or false                                         |
 | dontuseforce                | false    | Set this to true if you don't want to use --force when switching branches                                                                                                                           | true or false                                         |
 | usedocker                   | false    | Will deploy using Dockerfile in project root                                                                                                                                                        | true or false                                         |
+| context_path                | false    | Set if you want to set path to use as build context (defaults to Dockerfile dir)                                                                                                                    | . , api                                               |
+| userecursive                | false    | Set this to true if you want to use --recursive for pushes Dockerfile.<process> found in current and subdirectories                                                                                 | true or false                                         |
 | docker_heroku_process_type  | false    | Type of heroku process (web, worker, etc). This option only makes sense when usedocker enabled. Defaults to "web" (Thanks to [singleton11](https://github.com/singleton11) for adding this feature) | web, worker                                           |
 | docker_build_args           | false    | A list of args to pass into the Docker build. This option only makes sense when usedocker enabled.                                                                                                  | NODE_ENV                                              |
 | appdir                      | false    | Set if your app is located in a subdirectory                                                                                                                                                        | api, apis/python                                      |
@@ -162,6 +164,33 @@ jobs:
         env:
           NODE_ENV: production
           SECRET_KEY: ${{ secrets.MY_SECRET_KEY }}
+```
+
+You can use `userecursive` and `context_path` options if you storing Dockerfile in subdirectories, Heroku will searching Dockerfile in current and subdirectories and build at the context path.
+
+_.github/workflows/main.yml_
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "YOUR APP's NAME" #Must be unique in Heroku
+          heroku_email: "YOUR EMAIL"
+          usedocker: true
+          userecursive: true
+          context_path: "."
 ```
 
 Also, thanks to [Olav Sundfør](https://github.com/olaven) for adding the Docker feature and [Matt Stavola](https://github.com/mbStavola) for adding the ability to pass in build args.

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,14 @@ inputs:
   docker_build_args:
     description: "A list of args to pass into the Docker build. This option only makes sense when usedocker enabled"
     required: false
+  userecursive:
+    description: "Set this to true if you want to use --recursive for pushes Dockerfile.<process> found in current and subdirectories"
+    default: "false"
+    required: false
+  context_path:
+    description: "Set if you want to set path to use as build context (defaults to Dockerfile dir)"
+    default: ""
+    required: false
   appdir:
     description: "Set if your app is located in a subdirectory."
     default: ""

--- a/index.js
+++ b/index.js
@@ -71,11 +71,17 @@ const deploy = ({
   dockerHerokuProcessType,
   dockerBuildArgs,
   appdir,
+  userecursive,
+  context_path,
 }) => {
   const force = !dontuseforce ? "--force" : "";
   if (usedocker) {
     execSync(
-      `heroku container:push ${dockerHerokuProcessType} --app ${app_name} ${dockerBuildArgs}`,
+      `heroku container:push ${dockerHerokuProcessType} ${
+        userecursive ? "--recursive" : null
+      } ${
+        context_path ? `--context-path ${context_path}` : null
+      } --app ${app_name} ${dockerBuildArgs}`,
       appdir ? { cwd: appdir } : null
     );
     execSync(
@@ -151,6 +157,8 @@ let heroku = {
   region: core.getInput("region"),
   stack: core.getInput("stack"),
   team: core.getInput("team"),
+  userecursive: core.getInput("userecursive") === "false" ? false : true,
+  context_path: core.getInput("context_path"),
 };
 
 // Formatting


### PR DESCRIPTION
Add recursive and context-path options in `heroku container:push` command.

I have a problem when organizing code by push Dockerfile to docker folder, and I solved it by setting recursive and context-path manually in the local. So I think these options will be useful and flexible on GitHub Action.

Options:
- userecursive
- context_path

Ref: [heroku-container-push](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-container-push) 