### PR TITLE
Change stack while adding heroku remote

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const addRemote = ({ app_name, dontautocreate, buildpack, region, team, stack })
   try {
     execSync("heroku git:remote --app " + app_name);
     console.log("Added git remote heroku");
+    execSync("heroku stack:set " + stack);
   } catch (err) {
     if (dontautocreate) throw err;
 


### PR DESCRIPTION
- Imagine a user created a heroku app through heroku dashboard, default stack of the app will heroku-20.
  Then he want to deploy the app with our action by building docker images in heroku which demands app stack must be container.
  With this patch, he can do that easily without need to install heroku cli locally.