### PR TITLE
justlogin with docker registry

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,9 @@ if (heroku.dockerBuildArgs) {
       execSync(createCatFile(heroku));
       console.log("Created and wrote to ~/.netrc");
 
+      if (heroku.usedocker) {
+        execSync("heroku container:login");
+      }
       return;
     }
 


### PR DESCRIPTION
Hi! 
This is very useful actions.

I always push to docker registry and then release. The reason is that I want to use the docker build command. At that time, it is very convenient if I can justlogin with docker registry login. Consider this PR if there are no side effects.