### PR TITLE
Switch to node16, remove node12 deprecation notice

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,5 +87,5 @@ outputs:
   status:
     description: "The Success/Failure of the action"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
node12 has been deprecated and is scheduled to be disabled in 2023.