### PR TITLE
feat: bypass commit convention rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const addConfig = ({ app_name, env_file, appdir }) => {
 const createProcfile = ({ procfile, appdir }) => {
   if (procfile) {
     fs.writeFileSync(path.join(appdir, "Procfile"), procfile);
-    execSync(`git add -A && git commit -m "Added Procfile"`);
+    execSync(`git add -A && git commit --no-verify -m "Added Procfile"`);
     console.log("Written Procfile with custom configuration");
   }
 };
@@ -190,7 +190,7 @@ if (heroku.dockerBuildArgs) {
     const status = execSync("git status --porcelain").toString().trim();
     if (status) {
       execSync(
-        'git add -A && git commit -m "Commited changes from previous actions"'
+        'git add -A && git commit --no-verify -m "Commited changes from previous actions"'
       );
     }
 


### PR DESCRIPTION
# Problem

Since we have commit conventions enforced in our repo (thru [husky](https://github.com/typicode/husky)), we use options of this action who run a `git commit`

# Solution

Use no-verify flag to bypass like suggested [here](https://github.com/typicode/husky/issues/124#issuecomment-299847973)