### PR TITLE
Add Docker Context Path and Recursive Options Support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,14 @@ inputs:
   docker_build_args:
     description: "A list of args to pass into the Docker build. This option only makes sense when usedocker enabled"
     required: false
+  docker_context_path:
+    description: "Path to use as build context (defaults to Dockerfile dir). This option only makes sense when usedocker enabled"
+    required: false
+    default: ""
+  docker_find_recursive:
+    description: "Pushes Dockerfile.<process> found in current and subdirectories. This option only makes sense when usedocker enabled"
+    required: false
+    default: "false"
   appdir:
     description: "Set if your app is located in a subdirectory."
     default: ""

--- a/index.js
+++ b/index.js
@@ -77,12 +77,17 @@ const deploy = ({
   usedocker,
   dockerHerokuProcessType,
   dockerBuildArgs,
+  dockerContextPath,
+  dockerFindRecursive,
   appdir,
 }) => {
   const force = !dontuseforce ? "--force" : "";
   if (usedocker) {
+    const recursiveFlag = dockerFindRecursive ? "--recursive" : "";
+    const contextPathFlag = dockerContextPath ? `--context-path ${dockerContextPath}` : "";
+    
     execSync(
-      `heroku container:push ${dockerHerokuProcessType} --app ${app_name} ${dockerBuildArgs}`,
+      `heroku container:push ${dockerHerokuProcessType} --app ${app_name} ${dockerBuildArgs} ${recursiveFlag} ${contextPathFlag}`.trim().replace(/\s+/g, ' '),
       appdir ? { cwd: appdir } : null
     );
     execSync(
@@ -146,6 +151,8 @@ let heroku = {
   usedocker: core.getInput("usedocker") === "false" ? false : true,
   dockerHerokuProcessType: core.getInput("docker_heroku_process_type"),
   dockerBuildArgs: core.getInput("docker_build_args"),
+  dockerContextPath: core.getInput("docker_context_path"),
+  dockerFindRecursive: core.getInput("docker_find_recursive") === "false" ? false : true,
   appdir: core.getInput("appdir"),
   healthcheck: core.getInput("healthcheck"),
   checkstring: core.getInput("checkstring"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroku-deploy",
-  "version": "3.13.15",
+  "version": "3.13.16",
   "description": "A simple github action that dynamically deploys an app to heroku",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds support for two new Docker deployment options that enhance the flexibility of container deployments with Heroku:

- `docker_context_path` - Allows specifying a custom build context path
- `docker_find_recursive` - Enables deployment of multiple Docker containers from subdirectories

## Changes Made

### 🔧 Core Implementation
- **action.yml**: Added two new input parameters with proper descriptions and defaults
- **index.js**: 
  - Added input parameter parsing for the new options
  - Updated `deploy()` function to accept and use the new parameters
  - Modified `heroku container:push` command to include `--context-path` and `--recursive` flags
  - Implemented proper flag handling and command construction

### 📚 Documentation
- **README.md**:
  - Added new options to the options table with descriptions and examples
  - Created two new example sections:
    - "Deploy with Docker Context Path" - demonstrates custom build context usage
    - "Deploy with Multiple Docker Processes (Recursive)" - shows multi-container deployment
  - Added reference to Heroku Container Registry documentation

## New Features

### `docker_context_path`
- **Purpose**: Specify a custom build context path (defaults to Dockerfile directory)
- **Use Case**: When Dockerfile is not in root or you need specific directory structure
- **Example**: `docker_context_path: "."` (if you have a monorepo, for instance)

### `docker_find_recursive` 
- **Purpose**: Deploy multiple containers using `Dockerfile.<process>` files from current and subdirectories
- **Use Case**: Monorepo setups or applications with multiple services
- **Example**: Looks for `Dockerfile.web`, `Dockerfile.worker`, etc.

## Usage Examples

```yaml
# Using docker_context_path
- uses: akhileshns/heroku-deploy@v3.14.15
  with:
    heroku_api_key: ${{secrets.HEROKU_API_KEY}}
    heroku_app_name: "my-app"
    heroku_email: "user@example.com"
    usedocker: true
    docker_context_path: "."

# Using docker_find_recursive
- uses: akhileshns/heroku-deploy@v3.14.15
  with:
    heroku_api_key: ${{secrets.HEROKU_API_KEY}}
    heroku_app_name: "my-app"
    heroku_email: "user@example.com"
    usedocker: true
    docker_find_recursive: true
    docker_heroku_process_type: "web worker"